### PR TITLE
Add simple login workflow

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,3 @@
+[
+  {"username": "user", "password": "pass"}
+]

--- a/index.html
+++ b/index.html
@@ -1,5 +1,0 @@
-<html>
-  <body>
-    <p>Testing</p>
-  </body>
-</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Calculator</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="p-3">
+  <div class="container">
+    <h1 class="text-center mb-4">Calculator</h1>
+    <div class="row mb-2">
+      <div class="col-12">
+        <input id="display" type="text" class="form-control text-end" readonly>
+      </div>
+    </div>
+    <div id="buttons" class="row row-cols-4 g-2"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="p-3">
+  <div class="container">
+    <h1 class="text-center mb-4">Login</h1>
+    <form id="loginForm" method="POST" action="/login" class="mb-3">
+      <div class="mb-3">
+        <input type="text" name="username" class="form-control" placeholder="Username" required>
+      </div>
+      <div class="mb-3">
+        <input type="password" name="password" class="form-control" placeholder="Password" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Login</button>
+    </form>
+    <div id="error" class="text-danger"></div>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('error')) {
+    document.getElementById('error').textContent = 'Invalid credentials';
+  }
+});

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,37 @@
+const buttons = [
+  '7','8','9','/','4','5','6','*','1','2','3','-','0','.','=','+','C'
+];
+
+const container = document.getElementById('buttons');
+buttons.forEach(label => {
+  const div = document.createElement('div');
+  div.className = 'col';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn btn-secondary w-100';
+  btn.textContent = label;
+  div.appendChild(btn);
+  container.appendChild(div);
+});
+
+const display = document.getElementById('display');
+container.addEventListener('click', (e) => {
+  if (e.target.tagName !== 'BUTTON') return;
+  const value = e.target.textContent;
+  if (value === 'C') {
+    display.value = '';
+  } else if (value === '=') {
+    try {
+      const result = eval(display.value || '0');
+      if (!isFinite(result)) {
+        display.value = 'Error';
+      } else {
+        display.value = result;
+      }
+    } catch (err) {
+      display.value = 'Error';
+    }
+  } else {
+    display.value += value;
+  }
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,3 @@
+.btn {
+  padding: 1rem;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,85 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const publicDir = path.join(__dirname, 'public');
+const dataDir = path.join(__dirname, 'data');
+const usersPath = path.join(dataDir, 'users.json');
+
+function readUsers() {
+  try {
+    const data = fs.readFileSync(usersPath, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    return [];
+  }
+}
+
+function serveFile(res, filePath, contentType) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+function handleLogin(req, res) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    const params = new URLSearchParams(body);
+    const username = params.get('username');
+    const password = params.get('password');
+    const users = readUsers();
+    const user = users.find(u => u.username === username && u.password === password);
+    if (user) {
+      res.writeHead(302, { 'Location': '/index.html', 'Set-Cookie': 'login=true' });
+      res.end();
+    } else {
+      res.writeHead(302, { 'Location': '/login.html?error=1' });
+      res.end();
+    }
+  });
+}
+
+function isLoggedIn(req) {
+  const cookies = req.headers.cookie || '';
+  return cookies.split(';').some(c => c.trim() === 'login=true');
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url);
+  if (req.method === 'POST' && parsed.pathname === '/login') {
+    return handleLogin(req, res);
+  }
+
+  if (!isLoggedIn(req) && parsed.pathname !== '/login.html' && parsed.pathname !== '/login') {
+    res.writeHead(302, { 'Location': '/login.html' });
+    return res.end();
+  }
+
+  let filePath = path.join(publicDir, parsed.pathname);
+  if (parsed.pathname === '/') {
+    filePath = path.join(publicDir, 'index.html');
+  }
+
+  const ext = path.extname(filePath);
+  const contentTypes = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.css': 'text/css'
+  };
+  const contentType = contentTypes[ext] || 'text/plain';
+  serveFile(res, filePath, contentType);
+});
+
+const PORT = 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- organize static assets under `public`
- add Node.js server with login handling
- store user credentials in `data/users.json`
- add login page and style file
- update calculator logic to handle divide-by-zero

## Testing
- `npm test` *(fails: could not read package.json)*